### PR TITLE
Fix #banner background issue on large screen

### DIFF
--- a/style.css
+++ b/style.css
@@ -101,6 +101,7 @@ body{
 	background-color: #2196F3;
 	background-image: url(img/wall1.jpg);
 	background-position: right bottom;
+	background-size: cover;
 	margin: 0;
 	padding : 0;
 	width: 100%;


### PR DESCRIPTION
This is a nice thing to know when you need to have an image as a large background on a website.
This article explain very well why `background cover` is so cool.

Before :
![before_fix](https://cloud.githubusercontent.com/assets/2109178/12179987/44adb3a2-b57a-11e5-9010-2df8b31fc102.jpg)

After :
![after_fix](https://cloud.githubusercontent.com/assets/2109178/12179986/44aa7da4-b57a-11e5-8d8f-11515bad1e0e.jpg)
